### PR TITLE
release:1.1.0 - Adds Ability to pass in AwsCredentialsProvider with custom duration for generating token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2025-07-24
+
+- Added ability to pass in AwsCredentialsProvider to generate a token
+- Moved to builder pattern for creating instance
+- Added ability to dynamically set token duration upto 12 hours
+
 ## [1.0.0] - 2025-06-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@
 
 The **AWS Bedrock Token Generator for Java** is a lightweight utility library that generates short-term bearer tokens for AWS Bedrock API authentication. This library simplifies the process of creating secure, time-limited tokens that can be used to authenticate with AWS Bedrock services without exposing long-term credentials.
 
-## Features
-
-- ✅ **Simple API**: Single method to generate bearer tokens
-- ✅ **Secure**: Uses AWS SigV4 signing with 12-hour token expiration
-- ✅ **AWS SDK Integration**: Seamlessly works with AWS SDK credential providers
-- ✅ **Lightweight**: Minimal dependencies, focused functionality
-- ✅ **Well-tested**: Comprehensive unit tests with multiple scenarios
-
 ## Installation
 
 ### Maven
@@ -24,7 +16,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>software.amazon.bedrock</groupId>
     <artifactId>aws-bedrock-token-generator</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -33,66 +25,113 @@ Add the following dependency to your `pom.xml`:
 Add the following to your `build.gradle`:
 
 ```groovy
-implementation 'software.amazon.bedrock:aws-bedrock-token-generator:1.0.0'
+implementation 'software.amazon.bedrock:aws-bedrock-token-generator:1.1.0'
 ```
 
 ## Quick Start
 
-### Basic Usage
+NOTE - You may specify a custom token duration (e.g., 1 hour, 6 hours), but the actual token lifetime will be:
+min(specified duration, credentials expiry, 12 hours). Default is set to 12 hours
+
+### Usage 1 - Using Default Providers
 
 ```java
 import software.amazon.bedrock.token.BedrockTokenGenerator;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
 
-// Create token generator
-BedrockTokenGenerator tokenGenerator = new BedrockTokenGenerator();
-
-// Generate token using default credentials
-String bearerToken = tokenGenerator.getToken(
-    DefaultCredentialsProvider.create().resolveCredentials(),
-    Region.US_WEST_2.id()
-);
-
-// Use the token for API calls (valid for 12 hours)
-System.out.println("Bearer Token: " + bearerToken);
+// Credentials and region will be picked up from the default provider chain
+BedrockTokenGenerator tokenGenerator = BedrockTokenGenerator.builder().build();
+tokenGenerator.getToken();
 ```
 
-### Using with Specific Credentials
+### Usage 2 - Passing in Provider and Region
 
 ```java
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.bedrock.token.BedrockTokenGenerator;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
-// Create specific credentials
-AwsBasicCredentials credentials = AwsBasicCredentials.create(
-    "your-access-key-id",
-    "your-secret-access-key"
+// Example provider STS Assume Role credentials provider
+AwsCredentialsProvider assumeRoleProvider = StsAssumeRoleCredentialsProvider.builder()
+        .refreshRequest(AssumeRoleRequest.builder()
+                .roleArn("arn:aws:iam::123456789012:role/BedrockRole")
+                .roleSessionName("bedrock-token-session")
+                .durationSeconds(3600) // 1 hour
+                .build())
+        .build();
+
+        // Use provider and region with the token generator
+        BedrockTokenGenerator tokenGenerator = BedrockTokenGenerator.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(assumeRoleProvider)
+                .build();
+
+tokenGenerator.getToken();
+```
+
+### Usage 3 - creating token using static method by passing Credentials, Region, and Expiry (Optional)
+```java
+
+import software.amazon.bedrock.token.BedrockTokenGenerator;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import java.time.Duration;
+
+// Resolve credentials from default provider for example
+AwsCredentials credentials = DefaultCredentialsProvider.create().resolveCredentials();
+
+// Generate bearer token using static method
+String bearerToken = BedrockTokenGenerator.getToken(
+        credentials,
+        Region.US_WEST_2,
+        Duration.ofHours(12)
 );
-
-// Generate token
-BedrockTokenGenerator tokenGenerator = new BedrockTokenGenerator();
-String bearerToken = tokenGenerator.getToken(credentials, "us-east-1");
 ```
 
 ## API Reference
 
 ### BedrockTokenGenerator
 
-#### `getToken(AwsCredentials credentials, String region)`
+#### Static Method: `getToken(AwsCredentials credentials, Region region, Duration expiry)`
 
-Generates a bearer token for AWS Bedrock API authentication.
+Generates a bearer token for AWS Bedrock API authentication using static method.
 
 **Parameters:**
 - `credentials` (AwsCredentials): AWS credentials to use for signing
-- `region` (String): AWS region identifier (e.g., "us-west-2")
+- `region` (Region): AWS region object (e.g., Region.US_WEST_2)
+- `expiry` (Duration): Token expiration duration (e.g., Duration.ofHours(12))
 
 **Returns:**
-- `String`: A bearer token valid for 12 hours, prefixed with "bedrock-api-key-"
+- `String`: A bearer token valid for specified duration, prefixed with "bedrock-api-key-"
 
 **Example:**
 ```java
-BedrockTokenGenerator generator = new BedrockTokenGenerator();
-String token = generator.getToken(credentials, "us-west-2");
+String token = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, Duration.ofHours(12));
+```
+
+#### Builder Pattern: `builder()`
+
+Creates a BedrockTokenGenerator instance using the builder pattern.
+
+**Builder Methods:**
+- `region(Region region)`: Set the AWS region
+- `credentialsProvider(AwsCredentialsProvider provider)`: Set credentials provider
+- `expiry(Duration expiry)`: Set token expiration duration
+- `build()`: Create the BedrockTokenGenerator instance
+
+**Instance Method:**
+- `getToken()`: Generate token using configured settings
+
+**Example:**
+```java
+BedrockTokenGenerator generator = BedrockTokenGenerator.builder()
+    .region(Region.US_EAST_1)
+    .credentialsProvider(DefaultCredentialsProvider.create())
+    .expiry(Duration.ofHours(6))
+    .build();
+String token = generator.getToken();
 ```
 
 ## Token Format
@@ -105,11 +144,14 @@ bedrock-api-key-<base64-encoded-presigned-url>&Version=1
 - **Prefix**: `bedrock-api-key-` identifies the token type
 - **Payload**: Base64-encoded presigned URL with embedded credentials
 - **Version**: `&Version=1` for future compatibility
-- **Expiration**: 12 hours from generation time
+- **Expiration**: The token has a default expiration of 12 hour. If the expiresIn parameter is specified during token creation, the expiration can be configured up to a maximum of 12 hours. However, the actual token validity period will always
+  be the minimum of the requested expiration time and the AWS credentials' expiry time
 
 ## Security Considerations
 
-- **Token Expiration**: Tokens are valid for 12 hours and cannot be renewed
+- **Token Expiration**: The token has a default expiration of 12 hour. If the expiry parameter is specified during token creation, the expiration can be configured up to a maximum of 12 hours. However, the actual token validity period will always
+  be the minimum of the requested expiration time and the AWS credentials' expiry time. The token must be generated again once it expires,
+  as it cannot be refreshed or extended
 - **Secure Storage**: Store tokens securely and avoid logging them
 - **Credential Management**: Use IAM roles and temporary credentials when possible
 - **Network Security**: Always use HTTPS when transmitting tokens
@@ -128,16 +170,18 @@ bedrock-api-key-<base64-encoded-presigned-url>&Version=1
 ```java
 import software.amazon.bedrock.token.BedrockTokenGenerator;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.core.exception.SdkException;
+import java.time.Duration;
 
 public class BedrockTokenExample {
     public static void main(String[] args) {
         try {
-            BedrockTokenGenerator tokenGenerator = new BedrockTokenGenerator();
-            
-            String token = tokenGenerator.getToken(
+            // Using static method
+            String token = BedrockTokenGenerator.getToken(
                 DefaultCredentialsProvider.create().resolveCredentials(),
-                "us-west-2"
+                Region.US_WEST_2,
+                Duration.ofHours(12)
             );
             
             System.out.println("Successfully generated token: " + 
@@ -154,6 +198,8 @@ public class BedrockTokenExample {
 
 ```java
 import software.amazon.awssdk.auth.credentials.*;
+import software.amazon.awssdk.regions.Region;
+import java.time.Duration;
 
 // Default credentials (recommended)
 AwsCredentials defaultCreds = DefaultCredentialsProvider.create().resolveCredentials();
@@ -167,9 +213,30 @@ AwsCredentials sysCreds = SystemPropertyCredentialsProvider.create().resolveCred
 // Profile-based credentials
 AwsCredentials profileCreds = ProfileCredentialsProvider.create("my-profile").resolveCredentials();
 
-// Generate tokens with any credential provider
-BedrockTokenGenerator generator = new BedrockTokenGenerator();
-String token = generator.getToken(defaultCreds, "us-west-2");
+// Generate tokens with any credential provider using static method
+String token = BedrockTokenGenerator.getToken(defaultCreds, Region.US_WEST_2, Duration.ofHours(12));
+```
+
+### Using Builder with Different Configurations
+
+```java
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import java.time.Duration;
+
+// Builder with custom expiry
+BedrockTokenGenerator shortLivedGenerator = BedrockTokenGenerator.builder()
+    .region(Region.US_EAST_1)
+    .credentialsProvider(DefaultCredentialsProvider.create())
+    .expiry(Duration.ofHours(1))
+    .build();
+
+BedrockTokenGenerator defaultGenerator = BedrockTokenGenerator.builder()
+    .credentialsProvider(DefaultCredentialsProvider.create())
+    .build();
+
+String shortToken = shortLivedGenerator.getToken();
+String defaultToken = defaultGenerator.getToken();
 ```
 
 ## Building from Source
@@ -190,9 +257,9 @@ mvn package
 ```
 
 The build will generate:
-- `aws-bedrock-token-generator-1.0.0.jar` - Main library with dependencies
-- `aws-bedrock-token-generator-1.0.0-sources.jar` - Source code
-- `aws-bedrock-token-generator-1.0.0-javadoc.jar` - API documentation
+- `aws-bedrock-token-generator-1.1.0.jar` - Main library with dependencies
+- `aws-bedrock-token-generator-1.1.0-sources.jar` - Source code
+- `aws-bedrock-token-generator-1.1.0-javadoc.jar` - API documentation
 
 ## Contributing
 
@@ -204,7 +271,7 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for deta
 2. **Clone**: `git clone https://github.com/aws/aws-bedrock-token-generator-java.git`
 3. **Build**: `mvn clean compile`
 4. **Test**: `mvn test`
-****5. **Package**: `mvn package`****
+   ****5. **Package**: `mvn package`****
 
 ## Support
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.amazon.bedrock</groupId>
     <artifactId>aws-bedrock-token-generator</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>AWS Bedrock Token Generator</name>

--- a/src/main/java/software/amazon/bedrock/token/BedrockTokenGenerator.java
+++ b/src/main/java/software/amazon/bedrock/token/BedrockTokenGenerator.java
@@ -5,19 +5,26 @@
 package software.amazon.bedrock.token;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
-import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.Objects;
 
 /**
- * Utility class for generating bearer tokens for AWS Bedrock API authentication.
+ * BedrockTokenGenerator provides a lightweight utility to generate short-lived AWS Bearer tokens
+ * for use with the Amazon Bedrock API.
  */
 public class BedrockTokenGenerator {
 
@@ -30,26 +37,76 @@ public class BedrockTokenGenerator {
     private static final String SERVICE_SIGNING_NAME = "bedrock";
     private static final String AUTH_PREFIX = "bedrock-api-key-";
     private static final String TOKEN_VERSION = "&Version=1";
-    private static final Duration TOKEN_DURATION = Duration.ofHours(12);
+    private static final Duration DEFAULT_EXPIRY = Duration.ofHours(12);
+    private static final Duration MAX_EXPIRY = Duration.ofHours(12);
+    private static final String HTTPS_PREFIX = "https://";
+    private final Region region;
+    private final AwsCredentialsProvider credentialsProvider;
+    private final Duration expiry;
 
     /**
-     * Default constructor.
+     * Default constructor for who will directly call getToken(AwsCredentials, String).
      */
     public BedrockTokenGenerator() {
-        // Default constructor for future extensibility
+        this.region = null;
+        this.credentialsProvider = null;
+        this.expiry = DEFAULT_EXPIRY;
     }
 
     /**
-     * Generates a bearer token for AWS Bedrock API authentication.
+     * Private constructor used by the Builder
+     * Initializes region, credentials provider, and expiry duration with defaults if not explicitly provided.
      *
-     * @param credentials AWS credentials to use for signing
-     * @param region AWS region to use for the token
-     * @return A bearer token string valid for 12 hours, with version information embedded
+     * @param region The AWS region. If null, resolves from DefaultAwsRegionProviderChain.
+     * @param provider The AWS credentials provider. If null, uses DefaultCredentialsProvider.
+     * @param expiry Token expiration duration. Must be greater than 0 and less than or equal to 12 hours.
+     *               If null or invalid, defaults to 12 hours.
+     *
+     * @throws NullPointerException if region or credentials provider cannot be resolved from defaults
+     * @throws SdkClientException if default region or credentials provider cannot be initialized
+     * @throws IllegalArgumentException if expiry is less than or equal to 0 or greater than 12 hours
      */
-    public String getToken(AwsCredentials credentials, String region) {
+    private BedrockTokenGenerator(Region region, AwsCredentialsProvider provider, Duration expiry) {
+        this.region = region != null ? region : new DefaultAwsRegionProviderChain().getRegion();
+        this.credentialsProvider = provider != null ? provider : DefaultCredentialsProvider.create();
+        
+        Objects.requireNonNull(this.region, "Region must not be null and could not be obtained from default provider");
+        Objects.requireNonNull(this.credentialsProvider, "CredentialsProvider must not be null and" +
+                " could not be initialized from defaults");
+        
+        this.expiry = validateOrDefault(expiry);
+    }
+
+    /**
+     * Generates a bearer token using credentialsProvider and region provider during constructor
+     *
+     * @return A bearer token string.
+     * @throws SdkClientException if AWS credentials could not be resolved
+     */
+    public String getToken() {
+        AwsCredentials credentials = credentialsProvider.resolveCredentials();
+
+        return getToken(credentials, region, expiry);
+    }
+
+    /**
+     * Generates a bearer token using explicit AWS credentials and region.
+     *
+     * @param credentials AWS credentials.
+     * @param region The AWS region.
+     * @param expiry Token expiration duration (max 12 hours). If null or invalid, defaults to 12 hours.
+     * @return A bearer token string.
+     * @throws NullPointerException if credentials or region are null
+     * @throws IllegalArgumentException if expiry is less than or equal to 0 or greater than 12 hours
+     */
+    public static String getToken(AwsCredentials credentials, Region region, Duration expiry) {
+        Objects.requireNonNull(credentials, "Credentials must not be null");
+        Objects.requireNonNull(region, "Region must not be null");
+
+        expiry = validateOrDefault(expiry);
+
         AwsV4HttpSigner signer = AwsV4HttpSigner.create();
 
-        
         SdkHttpFullRequest sdkHttpRequest = SdkHttpFullRequest.builder()
                 .method(SdkHttpMethod.POST)
                 .protocol(PROTOCOL)
@@ -61,19 +118,101 @@ public class BedrockTokenGenerator {
 
         SignRequest signRequest = SignRequest.builder(credentials)
                 .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, SERVICE_SIGNING_NAME)
-                .putProperty(AwsV4HttpSigner.REGION_NAME, region)
+                .putProperty(AwsV4HttpSigner.REGION_NAME, region.id())
                 .putProperty(AwsV4HttpSigner.AUTH_LOCATION, AwsV4FamilyHttpSigner.AuthLocation.QUERY_STRING)
-                .putProperty(AwsV4HttpSigner.EXPIRATION_DURATION, TOKEN_DURATION)
+                .putProperty(AwsV4HttpSigner.EXPIRATION_DURATION, expiry)
                 .request(sdkHttpRequest)
                 .build();
 
         SdkHttpRequest signedRequest = signer.sign(signRequest).request();
         String uri = signedRequest.getUri().toString();
 
-        String encodedString = Base64.getEncoder().
-                encodeToString((uri.replaceFirst("^https://", "") + TOKEN_VERSION).
-                        getBytes(StandardCharsets.UTF_8));
+        String strippedUri = uri.startsWith(HTTPS_PREFIX)
+                ? uri.substring(HTTPS_PREFIX.length())
+                : uri;
+
+        String encodedString = Base64.getEncoder().encodeToString(
+                (strippedUri + TOKEN_VERSION).getBytes(StandardCharsets.UTF_8)
+        );
 
         return AUTH_PREFIX + encodedString;
+    }
+
+    /**
+     * Generates a bearer token using AWS credentials and region string.
+     * Expiry duration defaults to 12 hours.
+     * @param credentials AWS credentials.
+     * @param region Region name (e.g., "us-east-1").
+     * @return A bearer token string.
+     * @throws NullPointerException if credentials or region are null
+     * @throws IllegalArgumentException if region name is invalid
+     */
+    public String getToken(AwsCredentials credentials, String region) {
+        Objects.requireNonNull(credentials, "Credentials must not be null");
+        Objects.requireNonNull(region, "Region must not be null");
+        return getToken(credentials, Region.of(region), Duration.ofHours(12));
+    }
+
+    /**
+     * Validates the expiry duration or returns the default of 12 hours.
+     *
+     * @param expiry Expiry duration to validate.
+     * @return A valid duration (1 second to 12 hours).
+     * @throws IllegalArgumentException if expiry is invalid.
+     */
+    private static Duration validateOrDefault(Duration expiry) {
+        if (expiry == null) {
+            return DEFAULT_EXPIRY;
+        }
+        if (expiry.compareTo(Duration.ZERO) <= 0 || expiry.compareTo(MAX_EXPIRY) > 0) {
+            throw new IllegalArgumentException("Expiry duration must be greater than 0 and less than or equal to 12 hours.");
+        }
+        return expiry;
+    }
+
+    /**
+     * Returns a builder instance for creating a BedrockTokenGenerator with custom configuration.
+     *
+     * @return A new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for BedrockTokenGenerator.
+     * Allows fluent creation of the generator with optional region, credentials provider, and expiry.
+     */
+    public static class Builder {
+        private Region region;
+        private AwsCredentialsProvider provider;
+        private Duration expiry;
+
+        public Builder region(Region region) {
+            this.region = region;
+            return this;
+        }
+
+        public Builder credentialsProvider(AwsCredentialsProvider provider) {
+            this.provider = provider;
+            return this;
+        }
+
+        public Builder expiry(Duration expiry) {
+            this.expiry = expiry;
+            return this;
+        }
+
+        /**
+         * Builds a BedrockTokenGenerator with the configured parameters.
+         * 
+         * @return A new BedrockTokenGenerator instance
+         * @throws SdkClientException if default region or credentials provider cannot be initialized
+         * @throws NullPointerException if region or credentials provider cannot be resolved
+         * @throws IllegalArgumentException if expiry is less than or equal to 0 or greater than 12 hours
+         */
+        public BedrockTokenGenerator build() {
+            return new BedrockTokenGenerator(region, provider, expiry);
+        }
     }
 }

--- a/src/test/java/software/amazon/bedrock/token/BedrockTokenGeneratorTest.java
+++ b/src/test/java/software/amazon/bedrock/token/BedrockTokenGeneratorTest.java
@@ -8,101 +8,317 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Assertions;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 
 import java.nio.charset.StandardCharsets;
-
-import static org.junit.jupiter.api.Assertions.*;
+import java.time.Duration;
+import java.util.stream.Stream;
 
 /**
  * Comprehensive tests for the BedrockTokenGenerator class.
  */
 public class BedrockTokenGeneratorTest {
 
-    private BedrockTokenGenerator tokenGenerator;
     private AwsCredentials credentials;
 
     @BeforeEach
     public void setup() {
-        // Setup test credentials and token generator instance
-        tokenGenerator = new BedrockTokenGenerator();
         credentials = AwsBasicCredentials.create("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     }
 
     @Test
-    public void testGenerateToken_ReturnsNonNullToken() {
-        // Act
-        String token = tokenGenerator.getToken(credentials, "us-west-2");
-        
-        // Assert
-        assertNotNull(token, "Token should not be null");
-        assertTrue(token.length() > 0, "Token should not be empty");
+    public void testStaticGetToken_ReturnsNonNullToken() {
+        String token = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, Duration.ofHours(12));
+
+        Assertions.assertNotNull(token, "Token should not be null");
+        Assertions.assertTrue(token.length() > 0, "Token should not be empty");
     }
 
     @Test
-    public void testGenerateToken_StartsWithCorrectPrefix() {
-        // Act
-        String token = tokenGenerator.getToken(credentials, "us-west-2");
-        
-        // Assert
-        assertTrue(token.startsWith("bedrock-api-key-"), 
+    public void testStaticGetToken_StartsWithCorrectPrefix() {
+        String token = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, Duration.ofHours(12));
+
+        Assertions.assertTrue(token.startsWith("bedrock-api-key-"),
                 "Token should start with the correct prefix");
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"us-east-1", "us-west-2", "eu-west-1", "ap-northeast-1"})
-    public void testGenerateToken_WithDifferentRegions(String region) {
-        // Act
-        String token = tokenGenerator.getToken(credentials, region);
-        
-        // Assert
-        assertNotNull(token, "Token should not be null for region: " + region);
-        assertTrue(token.startsWith("bedrock-api-key-"), 
-                "Token should start with the correct prefix for region: " + region);
+    public void testStaticGetToken_WithDifferentRegions(String regionStr) {
+        Region region = Region.of(regionStr);
+        String token = BedrockTokenGenerator.getToken(credentials, region, Duration.ofHours(12));
+
+        Assertions.assertNotNull(token, "Token should not be null for region: " + regionStr);
+        Assertions.assertTrue(token.startsWith("bedrock-api-key-"),
+                "Token should start with the correct prefix for region: " + regionStr);
     }
 
     @Test
-    public void testGenerateToken_TokenIsBase64Encoded() {
-        // Act
-        String token = tokenGenerator.getToken(credentials, "us-west-2");
-        
-        // Assert
+    public void testStaticGetToken_TokenIsBase64Encoded() {
+        String token = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, Duration.ofHours(12));
+
         String tokenWithoutPrefix = token.substring("bedrock-api-key-".length());
-        
-        // This will throw an IllegalArgumentException if the string is not valid Base64
+
         try {
             byte[] decoded = java.util.Base64.getDecoder().decode(tokenWithoutPrefix);
-            assertNotNull(decoded, "Decoded token should not be null");
+            Assertions.assertNotNull(decoded, "Decoded token should not be null");
         } catch (IllegalArgumentException e) {
-            fail("Token is not valid Base64: " + e.getMessage());
+            Assertions.fail("Token is not valid Base64: " + e.getMessage());
         }
     }
 
     @Test
-    public void testGenerateToken_ContainsVersionInfo() {
-        // Act
-        String token = tokenGenerator.getToken(credentials, "us-west-2");
-        
-        // Assert
+    public void testStaticGetToken_ContainsVersionInfo() {
+        String token = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, Duration.ofHours(12));
+
         String tokenWithoutPrefix = token.substring("bedrock-api-key-".length());
         byte[] decoded = java.util.Base64.getDecoder().decode(tokenWithoutPrefix);
         String decodedString = new String(decoded, StandardCharsets.UTF_8);
-        assertTrue(decodedString.contains("&Version=1"), 
+        Assertions.assertTrue(decodedString.contains("&Version=1"),
                 "Decoded token should contain version information");
     }
 
     @Test
-    public void testGenerateToken_DifferentCredentialsProduceDifferentTokens() {
-        // Arrange
+    public void testStaticGetToken_DifferentCredentialsProduceDifferentTokens() {
         AwsCredentials credentials1 = AwsBasicCredentials.create("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
         AwsCredentials credentials2 = AwsBasicCredentials.create("AKIAI44QH8DHBEXAMPLE", "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY");
-        
-        // Act
-        String token1 = tokenGenerator.getToken(credentials1, "us-west-2");
-        String token2 = tokenGenerator.getToken(credentials2, "us-west-2");
-        
-        // Assert
-        assertNotEquals(token1, token2, "Different credentials should produce different tokens");
+
+        String token1 = BedrockTokenGenerator.getToken(credentials1, Region.US_WEST_2, Duration.ofHours(12));
+        String token2 = BedrockTokenGenerator.getToken(credentials2, Region.US_WEST_2, Duration.ofHours(12));
+
+        Assertions.assertNotEquals(token1, token2, "Different credentials should produce different tokens");
+    }
+
+    @Test
+    public void testBuilder_WithAllParameters() {
+        BedrockTokenGenerator generator = BedrockTokenGenerator.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .expiry(Duration.ofHours(6))
+                .build();
+
+        String token = generator.getToken();
+
+        Assertions.assertNotNull(token, "Token should not be null");
+        Assertions.assertTrue(token.startsWith("bedrock-api-key-"), "Token should start with correct prefix");
+    }
+
+    @Test
+    public void testBuilder_WithDefaults() {
+        BedrockTokenGenerator generator = BedrockTokenGenerator.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+
+        String token = generator.getToken();
+
+        Assertions.assertNotNull(token, "Token should not be null");
+        Assertions.assertTrue(token.startsWith("bedrock-api-key-"), "Token should start with correct prefix");
+    }
+
+    @Test
+    public void testStaticGetToken_NullCredentialsThrowsException() {
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            BedrockTokenGenerator.getToken(null, Region.US_WEST_2, Duration.ofHours(12));
+        });
+    }
+
+    @Test
+    public void testStaticGetToken_NullRegionThrowsException() {
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            BedrockTokenGenerator.getToken(credentials, null, Duration.ofHours(12));
+        });
+    }
+
+    @Test
+    public void testStaticGetToken_NullExpiryUsesDefault() {
+        String token = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, null);
+
+        Assertions.assertNotNull(token, "Token should not be null when expiry is null");
+        Assertions.assertTrue(token.startsWith("bedrock-api-key-"), "Token should start with correct prefix");
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidExpiryDurations")
+    public void testStaticGetToken_InvalidExpiryThrowsException(Duration invalidExpiry) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, invalidExpiry);
+        }, "Invalid expiry duration should throw IllegalArgumentException");
+    }
+
+    private static Stream<Arguments> invalidExpiryDurations() {
+        return Stream.of(
+                Arguments.of(Duration.ofSeconds(-1)),     // Negative duration
+                Arguments.of(Duration.ZERO),              // Zero duration
+                Arguments.of(Duration.ofHours(13)),       // Exceeds max 12 hours
+                Arguments.of(Duration.ofDays(1))          // Exceeds max 12 hours
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validExpiryDurations")
+    public void testStaticGetToken_ValidExpiryDurations(Duration validExpiry) {
+        String token = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, validExpiry);
+
+        Assertions.assertNotNull(token, "Token should not be null for valid expiry: " + validExpiry);
+        Assertions.assertTrue(token.startsWith("bedrock-api-key-"), "Token should start with correct prefix");
+    }
+
+    private static Stream<Arguments> validExpiryDurations() {
+        return Stream.of(
+                Arguments.of(Duration.ofSeconds(1)),      // Minimum valid duration
+                Arguments.of(Duration.ofMinutes(30)),     // 30 minutes
+                Arguments.of(Duration.ofHours(1)),        // 1 hour
+                Arguments.of(Duration.ofHours(6)),        // 6 hours
+                Arguments.of(Duration.ofHours(12))        // Maximum valid duration
+        );
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        BedrockTokenGenerator generator = new BedrockTokenGenerator();
+
+        // This test verifies the default constructor works without throwing exceptions
+        // We can't easily test the token generation without valid AWS credentials
+        Assertions.assertNotNull(generator, "Generator should be created successfully");
+    }
+
+    @Test
+    public void testBuilder_EmptyBuilder() {
+        BedrockTokenGenerator generator = BedrockTokenGenerator.builder().build();
+
+        Assertions.assertNotNull(generator, "Generator should be created with empty builder");
+    }
+
+    @Test
+    public void testBuilder_OnlyRegion() {
+        BedrockTokenGenerator generator = BedrockTokenGenerator.builder()
+                .region(Region.EU_WEST_1)
+                .build();
+
+        Assertions.assertNotNull(generator, "Generator should be created with only region specified");
+    }
+
+    @Test
+    public void testBuilder_OnlyCredentialsProvider() {
+        BedrockTokenGenerator generator = BedrockTokenGenerator.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+
+        Assertions.assertNotNull(generator, "Generator should be created with only credentials provider specified");
+    }
+
+    @Test
+    public void testBuilder_OnlyExpiry() {
+        BedrockTokenGenerator generator = BedrockTokenGenerator.builder()
+                .expiry(Duration.ofHours(3))
+                .build();
+
+        Assertions.assertNotNull(generator, "Generator should be created with only expiry specified");
+    }
+
+    @Test
+    public void testBuilder_FluentInterface() {
+        BedrockTokenGenerator generator = BedrockTokenGenerator.builder()
+                .region(Region.AP_SOUTHEAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .expiry(Duration.ofHours(8))
+                .build();
+
+        String token = generator.getToken();
+
+        Assertions.assertNotNull(token, "Token should not be null");
+        Assertions.assertTrue(token.startsWith("bedrock-api-key-"), "Token should start with correct prefix");
+    }
+
+    @Test
+    public void testGetTokenUsingInstanceMethod() {
+        BedrockTokenGenerator generator = new BedrockTokenGenerator();
+        String token = generator.getToken(credentials, "us-east-1");
+
+        Assertions.assertNotNull(token, "Token should not be null");
+        Assertions.assertTrue(token.startsWith("bedrock-api-key-"), "Token should start with correct prefix");
+    }
+
+    @Test
+    public void testTokenConsistency_SameInputsSameToken() {
+        Duration expiry = Duration.ofHours(6);
+        Region region = Region.US_WEST_2;
+
+        String token1 = BedrockTokenGenerator.getToken(credentials, region, expiry);
+        String token2 = BedrockTokenGenerator.getToken(credentials, region, expiry);
+
+        // Note: Tokens might be different due to timestamp differences, but structure should be consistent
+        Assertions.assertNotNull(token1, "First token should not be null");
+        Assertions.assertNotNull(token2, "Second token should not be null");
+        Assertions.assertTrue(token1.startsWith("bedrock-api-key-"), "First token should start with correct prefix");
+        Assertions.assertTrue(token2.startsWith("bedrock-api-key-"), "Second token should start with correct prefix");
+    }
+
+    @Test
+    public void testTokenStructure_ContainsExpectedComponents() {
+        String token = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, Duration.ofHours(12));
+
+        String tokenWithoutPrefix = token.substring("bedrock-api-key-".length());
+        byte[] decoded = java.util.Base64.getDecoder().decode(tokenWithoutPrefix);
+        String decodedString = new String(decoded, StandardCharsets.UTF_8);
+
+        Assertions.assertTrue(decodedString.contains("bedrock.amazonaws.com"),
+                "Decoded token should contain the bedrock host");
+        Assertions.assertTrue(decodedString.contains("Action=CallWithBearerToken"),
+                "Decoded token should contain the correct action");
+        Assertions.assertTrue(decodedString.contains("&Version=1"),
+                "Decoded token should contain version information");
+    }
+
+    @Test
+    public void testDifferentRegionsProduceDifferentTokens() {
+        String tokenUsWest2 = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, Duration.ofHours(12));
+        String tokenEuWest1 = BedrockTokenGenerator.getToken(credentials, Region.EU_WEST_1, Duration.ofHours(12));
+
+        Assertions.assertNotEquals(tokenUsWest2, tokenEuWest1,
+                "Different regions should produce different tokens");
+    }
+
+    @Test
+    public void testDifferentExpiriesProduceDifferentTokens() {
+        String token1Hour = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, Duration.ofHours(1));
+        String token6Hours = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, Duration.ofHours(6));
+
+        Assertions.assertNotEquals(token1Hour, token6Hours,
+                "Different expiry durations should produce different tokens");
+    }
+
+    @Test
+    public void testTokenLength_ReasonableSize() {
+        String token = BedrockTokenGenerator.getToken(credentials, Region.US_WEST_2, Duration.ofHours(12));
+
+        // Token should be reasonably sized (not too short or excessively long)
+        Assertions.assertTrue(token.length() > 50, "Token should be longer than 50 characters");
+        Assertions.assertTrue(token.length() < 2000, "Token should be shorter than 2000 characters");
+    }
+
+    @Test
+    public void testBuilder_NullValues() {
+        BedrockTokenGenerator generator = BedrockTokenGenerator.builder()
+                .region(null)
+                .credentialsProvider(null)
+                .expiry(null)
+                .build();
+
+        Assertions.assertNotNull(generator, "Generator should handle null values gracefully");
+    }
+
+    @Test
+    public void testValidateOrDefault_ReturnsDefaultWhenNull() throws Exception {
+        java.lang.reflect.Method method = BedrockTokenGenerator.class.getDeclaredMethod("validateOrDefault", Duration.class);
+        method.setAccessible(true);
+        Duration result = (Duration) method.invoke(null, (Object) null);
+        Assertions.assertEquals(Duration.ofHours(12), result);
     }
 }


### PR DESCRIPTION
*Description of changes:*

* Added getToken(AwsCredentials credentials, Region region, Duration expiry) method to generate token with custom duration
* Moved to builder pattern for creating instance
* Minor refactoring
* Backward compatible changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
